### PR TITLE
Lowered your import line value

### DIFF
--- a/src/org/ryancutter/payrollbuddy/EmpProfile.java
+++ b/src/org/ryancutter/payrollbuddy/EmpProfile.java
@@ -9,13 +9,7 @@ import android.os.Bundle;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
-import android.widget.AdapterView;
-import android.widget.ArrayAdapter;
-import android.widget.Button;
-import android.widget.CheckBox;
-import android.widget.EditText;
-import android.widget.Spinner;
-import android.widget.Toast;
+import android.widget.*; 
 
 public class EmpProfile extends Activity {
     private EditText mNameText;


### PR DESCRIPTION
import android.widget.AdapterView;
import android.widget.ArrayAdapter;
import android.widget.Button;
import android.widget.CheckBox;
import android.widget.EditText;
import android.widget.Spinner;
import android.widget.Toast;
// ALL OF THOSE ABOVE WERE REPLACED WITH //
import android.widget.*;  

// It is only optional. But a wildcard operator will save you a little bit of space. 
// Let me know if it still works properly.